### PR TITLE
Remove print statement that breaks python3 support

### DIFF
--- a/outbound/__init__.py
+++ b/outbound/__init__.py
@@ -396,7 +396,6 @@ def __subscription(user_id, unsubscribe, all_campaigns=False, campaign_ids=None,
         data['campaign_ids'] = campaign_ids
 
     try:
-        print __HEADERS
         resp = requests.post(
             url,
             data=json.dumps(data),


### PR DESCRIPTION
Python3 no longer supports `print` as a statement. It appears that this line was left here from debugging.

I have run your tests on python3 with this change and they are passing.